### PR TITLE
chore(RSVP): ensure gitignore entries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,10 @@ certs/
 *.db
 *.txt
 .env*
+# Managed by gix gitignore workflow
+.env
+.env.*
+.DS_Store
+qodana.yaml
+tools/
+bin/


### PR DESCRIPTION
Ensure `.gitignore` contains the standard secrets/tooling entries (.env, tools/, bin/).